### PR TITLE
Use current time for date-related config defaults

### DIFF
--- a/cookiecutter.json
+++ b/cookiecutter.json
@@ -6,7 +6,7 @@
 	"repo_name": "sopel-beawesome",
 	"plugin_name": "beawesome",
 	"project_short_description": "A plugin for Sopel that makes everything awesome.",
-	"release_date": "2020-02-23",
-	"year": "2020",
+	"release_date": "{% now 'local', '%Y-%m-%d' %}",
+	"year": "{% now 'local', '%Y' %}",
 	"version": "0.1.0"
 }


### PR DESCRIPTION
No idea if there's any point in doing this, since the template never uses these values.

But I agree with @deathbybandaid that this is how they should behave.