### PR TITLE
Base more plugin-related values on sensible dynamic defaults

### DIFF
--- a/cookiecutter.json
+++ b/cookiecutter.json
@@ -1,10 +1,10 @@
 {
+	"plugin_name": "beawesome",
 	"full_name": "Anonymous Sopel Hacker",
 	"email": "you@domain.tld",
 	"github_username": "asopelhacker",
-	"project_name": "Sopel Cookiecutter",
-	"repo_name": "sopel-beawesome",
-	"plugin_name": "beawesome",
+	"repo_name": "sopel-{{ cookiecutter.plugin_name }}",
+	"project_name": "{{ cookiecutter.repo_name }}",
 	"project_short_description": "A plugin for Sopel that makes everything awesome.",
 	"release_date": "2020-02-23",
 	"year": "2020",


### PR DESCRIPTION
Prompting for the "plugin name" FIRST makes sense, since it's the main piece of information we need to fill in the template.

Later on, we can use that name to suggest sensible default values for naming the repo, "project", etc. that align with the conventions we use in the Sopel project/org itself (thus nudging plugin developers toward those same conventions).