### PR TITLE
README: Tell users about setting defaults with .cookiecutterrc

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,28 @@ Obviously, you can modify anything that the template builds, so don't feel
 constrained to this one way of doing things. Please do submit PRs to this repo
 if you think the template can be improved.
 
+## Setting defaults (name, email, username)
+
+If you find yourself creating plugins fairly often, you'll likely get tired of
+typing in your name, email address, and GitHub username every time.
+Fortunately, cookiecutter itself provides a way to specify default values via a
+`.cookiecutterrc` file in your home directory. For example, this snippet:
+
+```yaml
+default_context:
+    full_name: "dgw"
+    email: "dgw@example.com"
+    github_username: "dgw"
+```
+
+would override the default values for this template's `full_name`, `email`, and
+`github_username` fields, meaning you could just press Enter to accept each of
+these instead of retyping your info every time.
+
+Read more [in cookiecutter's documentation][cookiecutter-user-config].
+
+  [cookiecutter-user-config]: https://cookiecutter.readthedocs.io/en/latest/advanced/user_config.html
+
 ## Legacy module template
 If you need to build a new plugin that will be compatible with Sopel 6, use the
 legacy template:


### PR DESCRIPTION
I got tired of typing even fake details into the template each time, so people who actually use these templates regularly must be super annoyed. For the benefit of all users (except maybe those who already know about this feature), our README should point them toward how to avoid such repetitive typing.