### PR TITLE
Flesh out README template

### DIFF
--- a/cookiecutter.json
+++ b/cookiecutter.json
@@ -5,6 +5,7 @@
 	"github_username": "asopelhacker",
 	"repo_name": "sopel-{{ cookiecutter.plugin_name }}",
 	"project_name": "{{ cookiecutter.repo_name }}",
+	"package_name": "{{ cookiecutter.repo_name }}",
 	"project_short_description": "A plugin for Sopel that makes everything awesome.",
 	"release_date": "{% now 'local', '%Y-%m-%d' %}",
 	"year": "{% now 'local', '%Y' %}",

--- a/{{cookiecutter.repo_name}}/README.md
+++ b/{{cookiecutter.repo_name}}/README.md
@@ -1,3 +1,17 @@
 # {{cookiecutter.project_name}}
 
 {{cookiecutter.project_short_description}}
+
+## Installing
+
+Releases are hosted on PyPI, so after installing Sopel, all you need is `pip`:
+
+```shell
+$ pip install {{cookiecutter.package_name}}
+```
+
+## Configuring
+
+The easiest way to configure `{{cookiecutter.project_name}}` is via Sopel's
+configuration wizard—simply run `sopel-plugins configure {{cookiecutter.plugin_name}}`
+and enter the values for which it prompts you.


### PR DESCRIPTION
Added a `package_name` field to cookiecutter's prompts (default: `repo_name`) and added "Installing" & "Configuring" sections to the template readme. "Installing" uses the new package name value.